### PR TITLE
Majority of zoom simulation is greyer now

### DIFF
--- a/src/app/(simulations)/behavioral/(components)/BehavioralSimulationPage.jsx
+++ b/src/app/(simulations)/behavioral/(components)/BehavioralSimulationPage.jsx
@@ -381,7 +381,7 @@ const InterviewQuestions = ({questions}) => {
                     md: 'calc(100vw - 240px)'
                 },
                 height: 'calc(100vh - 100px)',
-                backgroundColor: '#1f1f23',
+                backgroundColor: '#2a2a2e',
                 display: 'flex',
                 flexDirection: 'column',
                 overflow: 'hidden'
@@ -394,7 +394,7 @@ const InterviewQuestions = ({questions}) => {
                 left: 0,
                 right: 0,
                 height: '60px',
-                backgroundColor: 'rgba(0,0,0,0.8)',
+                backgroundColor: '#1f1f23',
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'space-between',
@@ -711,7 +711,7 @@ const InterviewQuestions = ({questions}) => {
                 left: 0,
                 right: 0,
                 height: '80px',
-                backgroundColor: 'rgba(0,0,0,0.9)',
+                backgroundColor: '#1f1f23',
                 display: 'flex',
                 alignItems: 'flex-start',
                 justifyContent: 'center',

--- a/src/app/(simulations)/behavioral/(components)/BehavioralSimulationPage.jsx
+++ b/src/app/(simulations)/behavioral/(components)/BehavioralSimulationPage.jsx
@@ -381,7 +381,7 @@ const InterviewQuestions = ({questions}) => {
                     md: 'calc(100vw - 240px)'
                 },
                 height: 'calc(100vh - 100px)',
-                backgroundColor: '#2a2a2e',
+                backgroundColor: '#222223ff',
                 display: 'flex',
                 flexDirection: 'column',
                 overflow: 'hidden'
@@ -394,7 +394,7 @@ const InterviewQuestions = ({questions}) => {
                 left: 0,
                 right: 0,
                 height: '60px',
-                backgroundColor: '#1f1f23',
+                backgroundColor: '#000000ff',
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'space-between',
@@ -633,7 +633,7 @@ const InterviewQuestions = ({questions}) => {
                 <Box
                     sx={{
                     position: "absolute",
-                    bottom: "calc(80px + 16px)", 
+                    bottom: "calc(95px + 16px)", 
                     left: "50%",
                     transform: "translateX(-50%)",
                     backgroundColor: "rgba(0,0,0,0.7)",
@@ -711,7 +711,7 @@ const InterviewQuestions = ({questions}) => {
                 left: 0,
                 right: 0,
                 height: '80px',
-                backgroundColor: '#1f1f23',
+                backgroundColor: '#000000ff',
                 display: 'flex',
                 alignItems: 'flex-start',
                 justifyContent: 'center',

--- a/src/app/(simulations)/behavioral/page.js
+++ b/src/app/(simulations)/behavioral/page.js
@@ -138,7 +138,7 @@ export default function BehavioralInterviewSimulation() {
                                     display: 'flex', 
                                     justifyContent: 'center', 
                                     alignItems: 'center', 
-                                    backgroundColor: '#000000', // Black background
+                                    backgroundColor: '#2a2a2e', // Black background
                                     zIndex: 1000
                                 }}>
                                     {/* Loading content container */}


### PR DESCRIPTION
- one issue where the bar right below the buttons is still black? not sure what's causing this?
<img width="1274" height="909" alt="Screenshot 2025-09-16 at 4 45 13 PM" src="https://github.com/user-attachments/assets/31b21c4f-47f9-4955-b4b1-9a766f19fa67" />
